### PR TITLE
New prediction API

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: datarobot
-version: '0.1.1'
+version: '1.0.0'
 category: Web
 author: Sean Hess
 maintainer: seanhess@gmail.com

--- a/src/DataRobot.hs
+++ b/src/DataRobot.hs
@@ -16,7 +16,6 @@ module DataRobot
   , Fields
   , PredictError(..)
   , PredictResult(..)
-  , responseResult
   , predictionValue
 
 

--- a/src/DataRobot.hs
+++ b/src/DataRobot.hs
@@ -17,7 +17,7 @@ module DataRobot
   , PredictError(..)
   , PredictResult(..)
   , responseResult
-  , classProbability
+  , predictionValue
 
 
 

--- a/src/DataRobot/API.hs
+++ b/src/DataRobot/API.hs
@@ -2,13 +2,13 @@ module DataRobot.API where
 
 import Lens.Micro ((^.))
 import Data.ByteString.Lazy (ByteString)
-import Data.Aeson (FromJSON, eitherDecode, decode)
+import Data.Aeson (FromJSON, eitherDecode)
 import Data.List (intercalate)
 import Data.Typeable (Typeable)
 import Data.Monoid ((<>))
 import Control.Monad.Catch (MonadThrow, Exception, throwM)
 import Network.URI (URI(..), pathSegments, uriToString)
-import Network.Wreq (Response, responseBody, headers)
+import Network.Wreq (Response, responseBody)
 
 data JSONError = JSONError String ByteString
                deriving (Typeable, Show)

--- a/src/DataRobot/API.hs
+++ b/src/DataRobot/API.hs
@@ -2,13 +2,13 @@ module DataRobot.API where
 
 import Lens.Micro ((^.))
 import Data.ByteString.Lazy (ByteString)
-import Data.Aeson (FromJSON, eitherDecode)
+import Data.Aeson (FromJSON, eitherDecode, decode)
 import Data.List (intercalate)
 import Data.Typeable (Typeable)
 import Data.Monoid ((<>))
 import Control.Monad.Catch (MonadThrow, Exception, throwM)
 import Network.URI (URI(..), pathSegments, uriToString)
-import Network.Wreq (Response, responseBody)
+import Network.Wreq (Response, responseBody, headers)
 
 data JSONError = JSONError String ByteString
                deriving (Typeable, Show)
@@ -20,7 +20,6 @@ parseResponse r =
   case eitherDecode $ r ^. responseBody of
     Left err -> throwM $ JSONError err (r ^. responseBody)
     Right p -> pure p
-
 
 endpoint :: URI -> [String] -> String
 endpoint base ps =

--- a/src/DataRobot/API.hs
+++ b/src/DataRobot/API.hs
@@ -21,6 +21,7 @@ parseResponse r =
     Left err -> throwM $ JSONError err (r ^. responseBody)
     Right p -> pure p
 
+
 endpoint :: URI -> [String] -> String
 endpoint base ps =
     let ps' = "" : pathSegments base <> ps

--- a/src/DataRobot/Predict.hs
+++ b/src/DataRobot/Predict.hs
@@ -8,11 +8,10 @@ module DataRobot.Predict
   , ModelID(..)
   ) where
 
-import Lens.Micro ((?~), (.~), (^?), (^.))
+import Lens.Micro ((?~), (.~))
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Catch (MonadThrow)
-import Data.Aeson (Value(..), encode, decode)
-import Data.ByteString (ByteString)
+import Data.Aeson (Value(..), encode)
 import Data.Function ((&))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
@@ -26,7 +25,6 @@ import Network.URI (URI(..))
 import qualified Network.Wreq as Wreq
 import Network.Wreq (defaults, Auth, basicAuth, auth, header, checkResponse)
 import Network.Wreq.Types (ResponseChecker)
-import Debug.Trace
 
 
 -- https://app.datarobot.com/docs/users-guide/basics/predictions/prediction-api.html

--- a/src/DataRobot/Predict.hs
+++ b/src/DataRobot/Predict.hs
@@ -8,23 +8,25 @@ module DataRobot.Predict
   , ModelID(..)
   ) where
 
-import Lens.Micro ((?~), (.~))
+import Lens.Micro ((?~), (.~), (^?), (^.))
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Catch (MonadThrow)
-import Data.Aeson (Value(..))
+import Data.Aeson (Value(..), encode, decode)
+import Data.ByteString (ByteString)
 import Data.Function ((&))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import Data.String.Conversions (cs)
 
 import DataRobot.Types
-import DataRobot.API (parseResponse, endpoint)
+import DataRobot.API (endpoint)
 import DataRobot.PredictResponse
 
 import Network.URI (URI(..))
 import qualified Network.Wreq as Wreq
 import Network.Wreq (defaults, Auth, basicAuth, auth, header, checkResponse)
 import Network.Wreq.Types (ResponseChecker)
+import Debug.Trace
 
 
 -- https://app.datarobot.com/docs/users-guide/basics/predictions/prediction-api.html
@@ -34,7 +36,7 @@ predict c pid mid o = do
       url = predictURI (baseURLPredict c) pid mid
       body = Array $ V.singleton $ Object $ HM.fromList o
   r <- liftIO $ Wreq.postWith opts url body
-  pr <- parseResponse r
+  let pr = parseResponse mid r
   pure $ responseResult pr
 
 

--- a/src/DataRobot/Predict.hs
+++ b/src/DataRobot/Predict.hs
@@ -34,8 +34,7 @@ predict c pid mid o = do
       url = predictURI (baseURLPredict c) pid mid
       body = Array $ V.singleton $ Object $ HM.fromList o
   r <- liftIO $ Wreq.postWith opts url body
-  let pr = parseResponse mid r
-  pure $ responseResult pr
+  pure $ parseResponse r
 
 
 httpOptions :: Credentials -> Wreq.Options

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -8,21 +8,16 @@ module DataRobot.PredictResponse
   , responseResult
   , parseResponse
   , predictionValue
-  ) where
-
-import Control.Applicative ((<|>))
+  ) where 
 import Control.Monad.Catch (Exception)
-import Data.Aeson (FromJSON(..), ToJSON, Value(..), withObject, (.:), encode, decode, decodeStrict, eitherDecode)
-import Data.Aeson.Types (Parser, parseMaybe, parseEither)
+import Data.Aeson (FromJSON(..), ToJSON, Value(..), withObject, (.:), decodeStrict, eitherDecode)
 import Data.List (find)
-import Data.Maybe (fromMaybe, maybe)
+import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Safe (headMay)
-import Text.Read (readMaybe)
-import Debug.Trace
 
 import Lens.Micro ((^.))
 import DataRobot.Types (ModelID(..))
@@ -71,11 +66,11 @@ instance ToJSON PredictionValue
 instance FromJSON PredictionValue where
   parseJSON = withObject "prediction_value" $ \o ->
     do
-      value <- o .: "value"
-      label <- o .: "label"
-      case labelText label of
-        Just l  -> return $ PredictionValue l value
-        Nothing -> fail $ "Invalid label: " <> show label
+      value' <- o .: "value"
+      label' <- o .: "label"
+      case labelText label' of
+        Just l  -> return $ PredictionValue l value'
+        Nothing -> fail $ "Invalid label: " <> show label'
     where
       -- Always treat the label as text even though the JSON allows for numbers
       -- This makes label based lookup easier on the API consumer

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -128,8 +128,8 @@ parseResponse r = do
       tm :: Float
       tm = fromMaybe 0.0 $ decode (cs et)
 
-      successResponse :: [Prediction] -> Either PredictError PredictResult
-      successResponse preds = responseResult tm $ ResponseSuccess { _data = preds }
+      successResponse :: ResponseSuccess -> Either PredictError PredictResult
+      successResponse (ResponseSuccess preds) = responseResult tm $ ResponseSuccess { _data = preds }
 
 predictionValue :: Text -> PredictResult -> Maybe Float
 predictionValue c r = do

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -98,9 +98,7 @@ data PredictResult = PredictResult
 -- Create a result for a successful response
 responseSuccess :: Float -> ResponseSuccess -> Either PredictError PredictResult
 responseSuccess et rs =
-    maybe (Left MissingPrediction) Right createResult
-  where
-    createResult = do
+    maybe (Left MissingPrediction) Right $ do
         p <- headMay (_data rs)
         pure PredictResult
             { prediction       = _prediction p

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -5,16 +5,17 @@ module DataRobot.PredictResponse
   ( PredictError(..)
   , PredictResult(..)
   , PredictionValue(..)
-  , responseResult
   , parseResponse
   , predictionValue
-  ) where 
+  ) where
 import Control.Monad.Catch (Exception)
-import Data.Aeson (FromJSON(..), ToJSON, Value(..), withObject, (.:), decodeStrict, eitherDecode)
+import Data.Aeson (FromJSON(..), ToJSON, Value(..), decode, defaultOptions, genericToJSON, genericParseJSON, withObject, (.:), decodeStrict, eitherDecode)
+import Data.Aeson.Types (Options(..))
 import Data.List (find)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
+import Data.String.Conversions (cs)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Safe (headMay)
@@ -25,6 +26,11 @@ import Network.Wreq (Response, responseBody, responseHeader)
 import Data.ByteString.Lazy (ByteString)
 
 
+underscorePrefixOptions :: Options
+underscorePrefixOptions =
+  defaultOptions { fieldLabelModifier = dropWhile (== '_') }
+
+
 data PredictError
     = APIError Int Text
     | MissingPrediction
@@ -33,30 +39,25 @@ data PredictError
 instance Exception PredictError
 
 
-data ResponseBody = ResponseBody
-  { _predictions :: [Prediction]
+-- Datarobot successful response
+data ResponseSuccess = ResponseSuccess
+  { _data :: [Prediction]
   } deriving (Eq, Show, Generic)
 
-instance FromJSON ResponseBody where
-  parseJSON = withObject "response_body" $ \o -> do
-    d <- o .: "data"   -- predictions
-    pure $ ResponseBody { _predictions = d }
+instance FromJSON ResponseSuccess where
+  parseJSON = genericParseJSON underscorePrefixOptions
 
 
-data PredictSuccess = PredictSuccess
-  { predictions    :: [Prediction]
-  , model_id       :: Text
-  , execution_time :: Float
+-- Datarobot failure response
+data ResponseFailure = ResponseFailure
+  { _message :: Text
   } deriving (Show, Eq, Generic)
 
-data PredictFailure = PredictFailure
-  { message :: Text
-  } deriving (Show, Eq, Generic)
-
-type PredictResponse
-    = Either PredictFailure PredictSuccess
+instance FromJSON ResponseFailure where
+  parseJSON = genericParseJSON underscorePrefixOptions
 
 
+-- A single prediction value
 data PredictionValue = PredictionValue
   { label :: Text
   , value :: Float
@@ -78,55 +79,57 @@ instance FromJSON PredictionValue where
       labelText (String s) = Just s
       labelText _ = Nothing
 
+-- Combination of prediction values and prediction label
 data Prediction = Prediction
-  { prediction       :: Value
+  { prediction       :: Value  -- label or float
   , predictionValues :: Maybe [PredictionValue]
   } deriving (Eq, Show, Generic)
 
 instance FromJSON Prediction
 
 
-
 -- | Result from the prediction
-
 data PredictResult = PredictResult
   { prediction       :: Value
   , predictionTimeMs :: Float
-  , modelId          :: Text
   , values           :: Maybe [PredictionValue]
   } deriving (Show, Eq, Generic)
 
 
-responseResult :: PredictResponse -> Either PredictError PredictResult
-responseResult (Right ps) = do
-      fromMaybe (Left MissingPrediction) $ do
-        p <- headMay (predictions ps)
-        pure $ Right $ PredictResult
-          { prediction       = prediction (p :: Prediction)
-          , predictionTimeMs = execution_time ps
-          , modelId          = model_id ps
-          , values           = predictionValues p
-          }
-responseResult (Left pf) = do
-    Left $ APIError 422 (message pf)
+responseResult :: Float -> ResponseSuccess -> Either PredictError PredictResult
+responseResult time rs =
+    fromMaybe (Left MissingPrediction) $ (Right <$> responseSuccess time rs)
+
+responseFailure :: Text -> PredictError
+responseFailure e = APIError 422 e
+
+responseSuccess :: Float -> ResponseSuccess -> Maybe PredictResult
+responseSuccess t s = do
+    p <- headMay (_data s)
+    pure PredictResult
+        { prediction       = prediction (p :: Prediction)
+        , predictionTimeMs = t
+        , values           = predictionValues p
+        }
 
 -- Parse the entire prediction response
 -- This is needed because some of the data is delivered in the body and some is delivered via headers
-parseResponse :: ModelID -> Response ByteString -> PredictResponse
-parseResponse (ModelID mi) r =
-    let b  = r ^. responseBody
-        et = r ^. responseHeader "X-DataRobot-Execution-Time"
-    in
-      case eitherDecode b of
+parseResponse :: Response ByteString -> Either PredictError PredictResult
+parseResponse r = do
+    case eitherDecode b of
         Left err ->
-          Left $ PredictFailure { message = pack err }
+            Left $ responseFailure (cs err)
+        Right predictions ->
+            successResponse predictions
+    where
+      b  = r ^. responseBody
+      et = r ^. responseHeader "X-DataRobot-Execution-Time"
 
-        Right body ->
-          Right $ PredictSuccess
-            { predictions    = _predictions body
-            , model_id       = mi
-            , execution_time = fromMaybe 0.0 (decodeStrict et)
-            }
+      tm :: Float
+      tm = fromMaybe 0.0 $ decode (cs et)
+
+      successResponse :: [Prediction] -> Either PredictError PredictResult
+      successResponse preds = responseResult tm $ ResponseSuccess { _data = preds }
 
 predictionValue :: Text -> PredictResult -> Maybe Float
 predictionValue c r = do


### PR DESCRIPTION
Data Robot is deprecating the [prediction api](https://app.datarobot.com/docs/users-guide/basics/predictions/prediction-api.html) in favor of a [new one](https://app.datarobot.com/docs/users-guide/basics/predictions/new-prediction-api.html).  Because of this they only supporting multiclass models in the new API.  This branch implements the functionality to use the new prediction API.

For reference here is the json output of the new API:

```json
{
  "data": [
    {
      "predictionValues": [
        {
          "value": 0.2943840699,
          "label": 1.0
        },
        {
          "value": 0.7056159301,
          "label": 0.0
        }
      ],
      "prediction": 0.0,
      "rowId": 0
    }
  ]
}
```