### PR TITLE
Parse error body

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: datarobot
-version: '1.0.0'
+version: '1.0.1'
 category: Web
 author: Sean Hess
 maintainer: seanhess@gmail.com

--- a/src/DataRobot/Features.hs
+++ b/src/DataRobot/Features.hs
@@ -32,7 +32,7 @@ features c pid mid = do
 
 featuresEndpoint :: URI -> ProjectID -> ModelID -> String
 featuresEndpoint base (ProjectID pid) (ModelID mid) =
-    endpoint base ["projects", cs pid, "models", cs mid, "features"]
+    endpoint base ["projects", cs pid, "models", cs mid, "features/"]
 
 
 

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -8,6 +8,7 @@ module DataRobot.PredictResponse
   , parseResponse
   , predictionValue
   ) where
+import Control.Applicative ((<|>))
 import Control.Monad.Catch (Exception)
 import Data.Aeson (FromJSON(..), ToJSON, Value(..), decode, defaultOptions, genericParseJSON, withObject, (.:), eitherDecode)
 import Data.Aeson.Types (Options(..), typeMismatch)
@@ -55,6 +56,14 @@ data ResponseFailure = ResponseFailure
 instance FromJSON ResponseFailure where
   parseJSON = genericParseJSON underscorePrefixOptions
 
+-- Datarobot response
+data ResponseData
+  = ResponseData (Either ResponseFailure ResponseSuccess)
+  deriving (Eq, Show)
+
+instance FromJSON ResponseData where
+  parseJSON v = ResponseData <$>
+    ((Right <$> parseJSON v) <|> (Left <$> parseJSON v))
 
 -- A single prediction value
 data PredictionValue = PredictionValue
@@ -95,9 +104,9 @@ data PredictResult = PredictResult
   } deriving (Show, Eq, Generic)
 
 
--- Create a result for a successful response
-responseSuccess :: Float -> ResponseSuccess -> Either PredictError PredictResult
-responseSuccess et rs =
+-- Create a result for a data robot response
+handleResponse :: Float -> ResponseData -> Either PredictError PredictResult
+handleResponse et (ResponseData (Right rs)) =
     maybe (Left MissingPrediction) Right $ do
         p <- headMay (_data rs)
         pure PredictResult
@@ -105,6 +114,8 @@ responseSuccess et rs =
             , predictionValues = _predictionValues p
             , predictionTimeMs = et
             }
+handleResponse _ (ResponseData (Left err)) =
+    responseFailure $ _message err
 
 -- Create a result for a failed response
 responseFailure :: Text -> Either PredictError PredictResult
@@ -114,7 +125,7 @@ responseFailure e = Left $ APIError 422 e
 -- This is needed because some of the data is delivered in the body and some is delivered via headers
 parseResponse :: Response ByteString -> Either PredictError PredictResult
 parseResponse r = do
-    either (responseFailure . cs) (responseSuccess tm) $ eitherDecode b
+    either (responseFailure . cs) (handleResponse tm) $ eitherDecode b
     where
       b  = r ^. responseBody
       et = r ^. responseHeader "X-DataRobot-Execution-Time"

--- a/src/DataRobot/PredictResponse.hs
+++ b/src/DataRobot/PredictResponse.hs
@@ -34,9 +34,10 @@ type Code = Int
 data PredictError
     = APIError Code Text
     | MissingPrediction
-    deriving (Typeable, Show)
+    deriving (Typeable, Show, Generic)
 
 instance Exception PredictError
+instance ToJSON PredictError
 
 
 -- Datarobot successful response
@@ -91,6 +92,7 @@ data Prediction = Prediction
   , _predictionValues :: Maybe [PredictionValue]
   } deriving (Eq, Show, Generic)
 
+instance ToJSON Prediction
 instance FromJSON Prediction where
   parseJSON = genericParseJSON underscorePrefixOptions
 
@@ -102,6 +104,8 @@ data PredictResult = PredictResult
   , predictionTimeMs :: Float
   , predictionValues :: Maybe [PredictionValue]
   } deriving (Show, Eq, Generic)
+
+instance ToJSON PredictResult
 
 
 -- Create a result for a data robot response


### PR DESCRIPTION
We are currently not parsing datarobot error body:

```json
{"message": "..."}
```

Instead we return a json parsing error which obscures the error message from DR.  I believe the library used to handle this case and I changed the behavior recently.  So here's a fix, my bad :)

Also, I noticed that we always get a `301` response from datarobot on the features endpoint because it does not have a trailing `/`.  Updating the features URL to prevent the redirect, hopefully this makes feature calls marginally faster.